### PR TITLE
Fix blank page with some browser extensions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,12 +69,13 @@ export default {
         `
           <!doctype html><html><body><script>
             (() => {
-              window.addEventListener('message', ({ origin }) => {
+              window.addEventListener('message', ({ data, origin }) => {
+                if (data !== 'authorizing:${provider}') return;
                 window.opener.postMessage(
                   'authorization:${provider}:${state}:${JSON.stringify(content)}',
                   origin
                 );
-              }, { once: true });
+              });
               window.opener.postMessage('authorizing:${provider}', '*');
             })();
           </script></body></html>


### PR DESCRIPTION
I am setting up this script to use with Netlify CMS.
After the GitHub authorization popup, when the token is sent back to Netlify CMS on the `/callback` page, I got a blank page.

I found that this is caused by some browser extensions (e.g. [MetaMask](https://metamask.io/)) which use `window.postMessage` on page load to indicate to webpages that they are installed.
If the extension's message is received before the CMS's (which it is), this causes the `window.addEventListener('message', ..., { once: true })` to be triggered.
Because of the `once: true` option, it then ignores further events, including the one from the CMS to which we want to answer.

I thus removed that option and filtered incoming messages to only respond if it has the `authorizing:github` data (which is what Netlify CMS uses).
I can confirmed this fixed my issues, but I haven't tested specifically with Sveltia CMS.
My fork is currently deployed at https://sveltia-cms-auth.aurelien.garnier.dev and can be tested on https://aurelien.garnier.dev/admin (also allows localhost with `site_id=cms.netlify.com`).