### PR TITLE
support x-forwarded-proto

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,8 +57,15 @@ const outputHTML = ({ provider = 'unknown', token, error, errorCode }) => {
  * @returns {Promise<Response>} HTTP response.
  */
 const handleAuth = async (request, env) => {
-  const { url } = request;
-  const { origin, searchParams } = new URL(url);
+  const { url, headers } = request;
+  const parsed = new URL(url);
+
+  const forwardedProto = headers.get("x-forwarded-proto");
+  if (forwardedProto !== null) {
+    parsed.protocol = forwardedProto;
+  }
+
+  const { origin, searchParams } = parsed;
   const { provider, site_id: domain } = Object.fromEntries(searchParams);
 
   if (!provider || !supportedProviders.includes(provider)) {
@@ -159,7 +166,15 @@ const handleAuth = async (request, env) => {
  */
 const handleCallback = async (request, env) => {
   const { url, headers } = request;
-  const { origin, searchParams } = new URL(url);
+
+  const parsed = new URL(url);
+
+  const forwardedProto = headers.get("x-forwarded-proto");
+  if (forwardedProto !== null) {
+    parsed.protocol = forwardedProto;
+  }
+
+  const { origin, searchParams } = parsed;
   const { code, state } = Object.fromEntries(searchParams);
 
   const [, provider, csrfToken] =


### PR DESCRIPTION
The authenticator tries to determine its own URL from the http request object.

When deploying this on our own infrastructure (using `npm run start` in a container) and using an nginx reverse proxy for TLS, this leads the program to believe it is being accessed via http instead of https. The callback url is passed to our Gitlab instance with `http:` as the protocol instead of `https:`. While whitelisting the http endpoint in Gitlab (in addition to the https one) and adding a redirect in nginx does work, it's probably bad practice to do parts of the authentication flow via unencrypted http (i'm not familiar enough with oauth as to the exact security implications of doing this).

Helpfully, nginx provides the `x-forwarded-proto` header to indicate that we're in fact answering to an https request. This PR changes the handlers so that they check for that header and correct the URL's protocol if it's present.